### PR TITLE
Set up backend

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/rs/cors"
+
+	"github.com/gorilla/mux"
+)
+
+func main() {
+	r := mux.NewRouter()
+	r.HandleFunc("/ping", PingHandler)
+	r.PathPrefix("/").Handler(http.FileServer(http.Dir("./../frontend/build")))
+
+	handler := cors.Default().Handler(r)
+	fmt.Println("App running at http://localhost:9090")
+	log.Fatal(http.ListenAndServe("localhost:9090", handler))
+}

--- a/backend/pingHandler.go
+++ b/backend/pingHandler.go
@@ -1,0 +1,8 @@
+package main
+
+import "net/http"
+
+//PingHandler reply with pong!
+func PingHandler(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("pong!\n"))
+}


### PR DESCRIPTION
### What I did
- Set up backend

### How I did it
I used gorilla mux for routing. "github.com/rs/cors" was used to enable cross-site access.

### How to test it
- change directory into the root directory of this repository
- install go packages in the main.go file
- run `go run backend/*.go`
- open your browser and go to http:localhost:9090


### Other relevent details
I was unable to set up the backend with revel. 

The error returned by revel:
```
Revel executing: create a skeleton Revel application
CRIT  08:18:02 command_config.go:286: Abort: could not create a Revel application outside of GOPATH.
```

Also, the current application failed to catch all routes when I tried to catch all routes.

